### PR TITLE
Enabled C++11 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ clean: build
 	rm *.o
 
 build:
-	g++ -c src/*.cpp src/*.hpp
+	g++ -c src/*.cpp src/*.hpp --std=gnu++11
 	g++ *.o -o pong.out -lsfml-graphics -lsfml-window -lsfml-system -lsfml-network


### PR DESCRIPTION
Actually it was enabled previously, but compiler throwed warnings because it wasn't declared
